### PR TITLE
Update dkms.conf

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -3,7 +3,7 @@ PACKAGE_VERSION="9.007.01"
 PROCS_NUM=`nproc`
 [ $PROCS_NUM -gt 16 ] && PROCS_NUM=16
 MAKE="'make' -j$PROCS_NUM KVER=${kernelver} BSRC=/lib/modules/${kernelver} all"
-CLEAN="'make' clean"
+CLEAN="'make' clean KVER=${kernelver} BSRC=/lib/modules/${kernelver}"
 BUILT_MODULE_NAME[0]="r8125"
 BUILT_MODULE_LOCATION[0]="src"
 DEST_MODULE_LOCATION[0]="/updates"


### PR DESCRIPTION
如果不将KVER 传递给make clean ，在shell 中手工执行dkms build时候make clean 的KVER将为空值，虽然不影响结果，也可以改进。
例如：
'make' clean
/bin/sh: 1: VER: not found
make -C src/ KVER= BASEDIR=/lib/modules/5.13.19-2-pve clean

原因：未传递变量KVER