### PR TITLE
Fixed using wrong source code directory when installing new kernel

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -2,8 +2,8 @@ PACKAGE_NAME="realtek-r8125"
 PACKAGE_VERSION="9.012.03"
 PROCS_NUM=`nproc`
 [ $PROCS_NUM -gt 16 ] && PROCS_NUM=16
-MAKE="'make' -j$PROCS_NUM KVER=${kernelver} BSRC=/lib/modules/${kernelver} modules"
-CLEAN="'make' KVER=${kernelver} BSRC=/lib/modules/${kernelver} clean"
+MAKE="'make' -j$PROCS_NUM KVER=${kernelver} BASEDIR=/lib/modules/${kernelver} modules"
+CLEAN="'make' KVER=${kernelver} BASEDIR=/lib/modules/${kernelver} clean"
 BUILT_MODULE_NAME[0]="r8125"
 BUILT_MODULE_LOCATION[0]="src"
 DEST_MODULE_LOCATION[0]="/updates"


### PR DESCRIPTION
in src/Makefile line 135:
	BASEDIR := /lib/modules/$(shell uname -r)

When update a new kernel,  Using the variable BSRC does not overwrite the value of BASEDIR.