### PR TITLE
Add support for Ubuntu Mantic or up

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: contrib/kernel
 Priority: optional
 Maintainer: Deokgyu Yang <secugyu@gmail.com>
 Build-Depends: debhelper (>=11~), dkms (<< 3.0.3-3~) | dh-sequence-dkms
-Standards-Version: 4.1.4
+Standards-Version: 4.6.2.1
 Homepage: https://github.com/awesometic/realtek-r8125-dkms
 
 Package: realtek-r8125-dkms

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: realtek-r8125-dkms
 Section: contrib/kernel
 Priority: optional
 Maintainer: Deokgyu Yang <secugyu@gmail.com>
-Build-Depends: debhelper (>=11~), dkms
+Build-Depends: debhelper (>=11~), dkms (<< 3.0.3-3~) | dh-sequence-dkms
 Standards-Version: 4.1.4
 Homepage: https://github.com/awesometic/realtek-r8125-dkms
 


### PR DESCRIPTION
The dkms package in Build-Depends has been deprecated since Mantic. So add dh-sequence-dkms for the newer versions.