### PR TITLE
Rename BASEDIR to BSRC in dkms.conf

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -2,8 +2,8 @@ PACKAGE_NAME="realtek-r8125"
 PACKAGE_VERSION="9.013.02"
 PROCS_NUM=`nproc`
 [ $PROCS_NUM -gt 16 ] && PROCS_NUM=16
-MAKE="'make' -j$PROCS_NUM KVER=${kernelver} BASEDIR=/lib/modules/${kernelver} modules"
-CLEAN="'make' KVER=${kernelver} BASEDIR=/lib/modules/${kernelver} clean"
+MAKE="'make' -j$PROCS_NUM KVER=${kernelver} BSRC=/lib/modules/${kernelver} modules"
+CLEAN="'make' KVER=${kernelver} BSRC=/lib/modules/${kernelver} clean"
 BUILT_MODULE_NAME[0]="r8125"
 BUILT_MODULE_LOCATION[0]="src"
 DEST_MODULE_LOCATION[0]="/updates"


### PR DESCRIPTION
The Makefile checks for BSRC rather then BASEDIR and set BSRC to /lib/modules/$(shell uname -r) if not defined. Assign the proper variable in dkms.conf so that we are building against the correct kernel.