### PR TITLE
Add support for Realtek 8126 Ethernet controller (10ec:8126)

### DIFF
--- a/src/r8125_n.c
+++ b/src/r8125_n.c
@@ -204,7 +204,7 @@ static const struct {
 
 static struct pci_device_id rtl8125_pci_tbl[] = {
         { PCI_DEVICE(PCI_VENDOR_ID_REALTEK, 0x8125), },
-        { PCI_DEVICE(PCI_VENDOR_ID_REALTEK, 0x8126), .driver_data = RTL8125B },
+        { PCI_DEVICE(PCI_VENDOR_ID_REALTEK, 0x8126), },
         { PCI_DEVICE(PCI_VENDOR_ID_REALTEK, 0x8162), },
         { PCI_DEVICE(PCI_VENDOR_ID_REALTEK, 0x3000), },
         {0,},

--- a/src/r8125_n.c
+++ b/src/r8125_n.c
@@ -204,6 +204,7 @@ static const struct {
 
 static struct pci_device_id rtl8125_pci_tbl[] = {
         { PCI_DEVICE(PCI_VENDOR_ID_REALTEK, 0x8125), },
+        { PCI_DEVICE(PCI_VENDOR_ID_REALTEK, 0x8126), .driver_data = RTL8125B },
         { PCI_DEVICE(PCI_VENDOR_ID_REALTEK, 0x8162), },
         { PCI_DEVICE(PCI_VENDOR_ID_REALTEK, 0x3000), },
         {0,},


### PR DESCRIPTION
This PR adds support for the Realtek 8126 Ethernet controller (device ID 10ec:8126),
which appears to be a variant of the RTL8125 chip family. The device is found on newer
ASUS Z890 motherboards and fails to bind without this entry.

Tested on Linux Mint 21.3 with kernel 6.8.0 using r8125 driver v9.015.00.